### PR TITLE
Updating cloudscraper integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,23 @@ You can also just use "npm install boorutagparser-server" if you prefer.
 ### Linux (Debian-based)
 
 ```text
-curl -sL https://deb.nodesource.com/setup_5.x | sudo -E bash -
-sudo apt-get install -y nodejs
-npm install boorutagparser-server
+curl -sL https://deb.nodesource.com/setup_11.x | sudo -E bash -
+sudo apt-get install -y nodejs git
+sudo apt-get install git
+git clone https://github.com/jetboom/boorutagparser-server
+cd boorutagparser-server
+npm install
 
-nodejs boorutagparser-server
+node index.js
 ```
 
-Package might be named "node" instead of "nodejs" for some people.
+### Arch Linux
+
+```text
+sudo pacman -S nodejs npm git
+git clone https://github.com/jetboom/boorutagparser-server
+cd boorutagparser-server
+npm install
+
+node index.js
+```

--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ function handleRequest(req, response)
 			    headers: headers
 			}
 
-			cloudscraper.request(
+			cloudscraper(
 				{
 					method: 'GET',
                 	url:args,


### PR DESCRIPTION
I tried to get this up and running on my linux machine a few days ago but was met with errors when running the index.js file. I looked into it and cloudscraper had updated their library from v2 to v3. All that needed to be changed was a single method call.

I also updated the README to make installing the running the program a bit more clear on Debian and Arch.